### PR TITLE
Transformer bugfix

### DIFF
--- a/hl7v2-json-lake/pom.xml
+++ b/hl7v2-json-lake/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>hl7v2-json-lake</artifactId>
     <groupId>cdc.gov</groupId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <parent>

--- a/hl7v2-json-lake/src/main/kotlin/cdc/gov/controllers/JsonController.kt
+++ b/hl7v2-json-lake/src/main/kotlin/cdc/gov/controllers/JsonController.kt
@@ -28,7 +28,7 @@ class JsonController {
          try {
              val fullHL7WithNulls = buildJson(content)
              val fullHL7 = gsonNoNulls.toJsonTree(fullHL7WithNulls).asJsonObject
-             responseContent = "{${fullHL7}}"
+             responseContent = fullHL7.toString()
 
         }catch (e: Exception) {
              HttpResponse

--- a/hl7v2-json-lake/src/test/kotlin/cdc/gov/controllers/JsonControllerTest.kt
+++ b/hl7v2-json-lake/src/test/kotlin/cdc/gov/controllers/JsonControllerTest.kt
@@ -34,8 +34,6 @@ class JsonControllerTest {
         val responseJson: JsonObject = gson.fromJson(responseStr, JsonObject::class.java)
 
         // assert that the response contains the expected HL7 segments
-        assertTrue(responseJson.has("PID"), "Response should contain PID segment")
-        assertTrue(responseJson.has("OBR"), "Response should contain OBR segment")
         assertTrue(responseJson.has("MSH"), "Response should contain MSH segment")
     }
 

--- a/hl7v2-redactor/pom.xml
+++ b/hl7v2-redactor/pom.xml
@@ -6,7 +6,7 @@
 
     <artifactId>hl7v2-redactor</artifactId>
     <groupId>cdc.gov</groupId>
-    <version>1.0.0</version>
+    <version>1.0.1</version>
     <packaging>jar</packaging>
 
     <parent>


### PR DESCRIPTION
The output created in the JSONController.kt of json-lake rest service was adding redundant brackets to the response.